### PR TITLE
Preliminary refactoring #1

### DIFF
--- a/src/database/column.cpp
+++ b/src/database/column.cpp
@@ -1,8 +1,8 @@
 #include "column.h"
 
-namespace emerald
-{
-    Column::Column(){}
+namespace emerald {
+    Column::Column() {
+    }
 
     size_t Column::size() const {
         return fields_.size();

--- a/src/database/column_descriptor.cpp
+++ b/src/database/column_descriptor.cpp
@@ -1,16 +1,22 @@
 #include "column_descriptor.h"
 #include <iostream>
 
-namespace emerald
-{
-    ColumnDescriptor::ColumnDescriptor(int table_id, int column_id, std::string column_name, field_type type){
+namespace emerald {
+    ColumnDescriptor::ColumnDescriptor(int table_id, int column_id, std::string column_name, field_type type) {
         table_id_ = table_id;
         column_id_ = column_id;
         column_name_ = column_name;
         type_ = type;
     }
     
-    std::string ColumnDescriptor::get_column_name() const{
+    ColumnDescriptor::ColumnDescriptor(const ColumnDescriptor &column_desc) {
+        table_id_ = column_desc.get_table_id();
+        column_id_ = column_desc.get_column_id();
+        column_name_ = column_desc.get_column_name();
+        type_ = column_desc.get_column_type();
+    }
+
+    std::string ColumnDescriptor::get_column_name() const {
         return column_name_;
     }
 
@@ -22,14 +28,7 @@ namespace emerald
         return column_id_;
     }
 
-    int ColumnDescriptor::get_table_id() const{
+    int ColumnDescriptor::get_table_id() const {
         return table_id_;
-    }
-
-    ColumnDescriptor::ColumnDescriptor(const ColumnDescriptor &column_desc){
-        table_id_ = column_desc.get_table_id();
-        column_id_ = column_desc.get_column_id();
-        column_name_ = column_desc.get_column_name();
-        type_ = column_desc.get_column_type();
     }
 } // emerald

--- a/src/database/column_store.cpp
+++ b/src/database/column_store.cpp
@@ -4,26 +4,23 @@ namespace emerald
 {
     ColumnStore::ColumnStore(int table_id) : Table(table_id, Table::COLUMN_STORE){};
 
-    void ColumnStore::print() const{
-
+    // not implemented?
+    void ColumnStore::print() const {
     } 
 
-    size_t ColumnStore::size() const{
+    size_t ColumnStore::size() const {
         return columns_[0]->size();
     }
 
     void ColumnStore::insert_tuple(std::vector<Field*> fields) {
         if (columns_.size()==0) {
             /* we are inserting the first row. Initialize the columns */
-            for(size_t i = 0; i < fields.size(); i++)
-            {
+            for (size_t i = 0; i < fields.size(); i++) {
                 columns_.push_back(new Column());
             }
-            
         }
         
-        for(size_t i = 0; i < fields.size(); i++)
-        {
+        for (size_t i = 0; i < fields.size(); i++) {
             columns_[i]->insert(fields[i]);
         }
         

--- a/src/database/database.cpp
+++ b/src/database/database.cpp
@@ -4,53 +4,54 @@
 #include "column_store.h"
 #include <iostream>
 
-namespace emerald
-{
-    Database::Database(){
-
+namespace emerald {
+    Database::Database() {
     }
 
-    void Database::createTable(std::string table_name, std::vector<std::string> column_names, std::vector<std::string> column_types, Table::storageType type){
+    // line length exceeds 80 characters
+    void Database::createTable(std::string table_name, std::vector<std::string> column_names, std::vector<std::string> column_types, Table::storageType type) {
         tableIds.insert(std::pair<std::string, int>(table_name, tableIds.size()));
         //schema contains column name mapped to column's data type
-        Table* table=nullptr;
-        if(type == Table::ROW_STORE){
+        Table* table = nullptr;
+        if (type == Table::ROW_STORE) {
+            // dynamic memory allocation: need a destructor?
             table = new RowStore(tableIds.size()-1);
         } else {
             //column store
+            // dynamic memory allocation: need a destructor?
             table = new ColumnStore(tableIds.size()-1);
         }
         table->setTableDesc(table->get_table_id(), column_names, column_types);
             tables.push_back(table);
     }
 
-    Table* Database::getTable(int index){
+    Table* Database::getTable(int index) {
         return this->tables[index];
     }
 
-    std::vector<Table*> Database::getTables(){
+    std::vector<Table*> Database::getTables() {
         return this->tables;
     }
 
-    std::unordered_map<std::string, int> Database::getTableIds(){
+    std::unordered_map<std::string, int> Database::getTableIds() {
         return this->tableIds;
     }
 
-    void Database::printTable(std::string table_name){
+    void Database::printTable(std::string table_name) {
         this->tables[this->tableIds[table_name]]->print();
     }
 
-    Table* Database::getTableRef(std::string table_name){
+    Table* Database::getTableRef(std::string table_name) {
         return this->tables[this->tableIds[table_name]];
     }
 
-    int Database::getTableId(std::string table_name){
+    int Database::getTableId(std::string table_name) {
         return tableIds[table_name];
     }
 
-    Field* Database::get_field(int table_id, int tuple_id, int column_id){
+    Field* Database::get_field(int table_id, int tuple_id, int column_id) {
         Table* table = tables[table_id];
-        if (table->getStorageType()==Table::ROW_STORE) {
+        if (table->getStorageType() == Table::ROW_STORE) {
             return static_cast<RowStore*>(table)->get_tuple(tuple_id)->getField(column_id);
         } else {
             return static_cast<ColumnStore*>(table)->get_column(column_id)->get_field(tuple_id);

--- a/src/database/date_field.cpp
+++ b/src/database/date_field.cpp
@@ -5,7 +5,7 @@
 
 namespace emerald
 { 
-    DateField::DateField(std::string v): Field(field_type::DATE){
+    DateField::DateField(std::string v) : Field(field_type::DATE) {
         std::string date_format = "%m/%d/%y";
         std::istringstream ss(v);
         std::tm dt;
@@ -14,56 +14,59 @@ namespace emerald
         dt.tm_hour = 0;
         dt.tm_min = 0; 
         this->value = std::mktime(&dt);
-    };
+    }; // redundant semicolon?
 
-    void DateField::print() const{
+    DateField::DateField(const DateField& field) : Field(field_type::DATE) {
+        value = field.getValue();
+    }; // redundant semicolon?
+
+    void DateField::print() const {
         std::tm dt = *std::gmtime(&value);
         std::stringstream wss;
         wss << (std::put_time(&dt, "%m/%d/%y"));
         std::cout << wss.str() << " \n" ;
-    };
+    }; // redundant semicolon?
 
-    std::time_t DateField::getValue() const{
-        return this->value;
-    };
-
-    std::string toString(time_t value){
+    // function not declared in header file
+    // function used in filter()
+    std::string toString(time_t value) {
         std::tm dt = *std::gmtime(&value);
         std::stringstream wss;
         wss << (std::put_time(&dt, "%m/%d/%y"));
         return wss.str();
     };
 
-    bool DateField::filter(Predicate::opType op, Field* value){
+    bool DateField::filter(Predicate::opType op, Field* value) {
         DateField* date_value = static_cast<DateField*>(value);
-
-        switch (op)
-        {
-            case Predicate::opType::EQ :
+        switch (op) {
+            // SEG FAULT
+            // value is a variable, not a pointer; should not be dereferenced
+            case Predicate::opType::EQ:
                 return toString(this->value).compare(toString(date_value->getValue())) == 0 ;
                 break;
-            case Predicate::opType::NE :
+            case Predicate::opType::NE:
                 return std::difftime(this->value, date_value->getValue())!=0;
                 break;
-            case Predicate::opType::GT :
+            case Predicate::opType::GT:
                 return std::difftime(this->value, date_value->getValue())>0;
                 break;
-            case Predicate::opType::LT :
+            case Predicate::opType::LT:
                 return std::difftime(this->value, date_value->getValue())<0;
                 break;
-            case Predicate::opType::GE :
+            case Predicate::opType::GE:
                 return std::difftime(this->value, date_value->getValue())>=0;
                 break;
-            case Predicate::opType::LE :
+            case Predicate::opType::LE:
                 return std::difftime(this->value, date_value->getValue())<=0;
                 break;
             default:
                 return false;
                 break;
         } 
-    };
+    }; // redundant semicolon?
 
-    DateField::DateField(const DateField& field):Field(field_type::DATE){
-        value = field.getValue();
-    };
+    std::time_t DateField::getValue() const {
+        return this->value;
+    }; // redundant semicolon?
+
 } // emerald

--- a/src/database/double_field.cpp
+++ b/src/database/double_field.cpp
@@ -4,45 +4,48 @@
 
 namespace emerald
 {
-    DoubleField::DoubleField(double v):Field(field_type::DOUBLE),value(v){};
+    DoubleField::DoubleField(double v) : Field(field_type::DOUBLE), value(v) {
+    }; // redundant semicolon?
 
-    void DoubleField::print() const{
+    // line length exceeds 80 characters
+    DoubleField::DoubleField(const DoubleField& field) : Field(field_type::DOUBLE) {
+        value = field.getValue();
+    }; // redundant semicolon?
+
+    void DoubleField::print() const {
         std::cout << std::fixed << value << " ";
-    };
+    }; // redundant semicolon?
 
-    bool DoubleField::filter(Predicate::opType op, Field* value){
+    bool DoubleField::filter(Predicate::opType op, Field* value) {
         DoubleField* double_value = static_cast<DoubleField*>(value);
-        switch (op)
-        {
-            case Predicate::opType::EQ :
-                return this->value==double_value->getValue();
+        switch (op) {
+            // SEG FAULT
+            // value is a variable, not a pointer; should not be dereferenced
+            case Predicate::opType::EQ:
+                return this->value == double_value->getValue();
                 break;
-            case Predicate::opType::NE :
-                return this->value!= double_value->getValue();
+            case Predicate::opType::NE:
+                return this->value != double_value->getValue();
                 break;
-            case Predicate::opType::GT :
+            case Predicate::opType::GT:
                 return this->value > double_value->getValue();
                 break;
-            case Predicate::opType::LT :
+            case Predicate::opType::LT:
                 return this->value < double_value->getValue();
                 break;
-            case Predicate::opType::GE :
+            case Predicate::opType::GE:
                 return this->value >= double_value->getValue();
                 break;
-            case Predicate::opType::LE :
+            case Predicate::opType::LE:
                 return this->value <= double_value->getValue();
                 break;
             default:
                 return false;
                 break;
         } 
-    };
+    }; // redundant semicolon?
 
     double DoubleField::getValue() const{
         return this->value;
-    };
-
-    DoubleField::DoubleField(const DoubleField& field):Field(field_type::DOUBLE){
-        value = field.getValue();
-    };
+    }; // redundant semicolon?
 } // emerald

--- a/src/database/field.cpp
+++ b/src/database/field.cpp
@@ -1,7 +1,6 @@
 #include "field.h"
 #include "field_type.h"
 
-namespace emerald
-{
-    Field::Field(field_type type):type(type){};
+namespace emerald {
+    Field::Field(field_type type) : type(type) {};
 } // emerald

--- a/src/database/group.cpp
+++ b/src/database/group.cpp
@@ -38,6 +38,7 @@ namespace emerald
             }
             
         }
+        // what if the first if clause evaluates to false?
         return groups; 
     }
 } // emerald

--- a/src/database/integer_field.cpp
+++ b/src/database/integer_field.cpp
@@ -3,32 +3,34 @@
 
 namespace emerald
 {
-    IntegerField::IntegerField(int v):Field(field_type::INTEGER),value(v){};
+    IntegerField::IntegerField(int v) : Field(field_type::INTEGER), value(v) {
+    };
 
-    void IntegerField::print() const{
+    void IntegerField::print() const {
         std::cout << value << " ";
     };
 
-    bool IntegerField::filter(Predicate::opType op, Field* value){
+    bool IntegerField::filter(Predicate::opType op, Field* value) {
         IntegerField* int_value = static_cast<IntegerField*>(value);
-        switch (op)
-        {
-            case Predicate::opType::EQ :
-                return this->value==int_value->getValue();
+        switch (op) {
+            // SEG FAULT
+            // value is a variable, not a pointer; should not be dereferenced
+            case Predicate::opType::EQ:
+                return this->value == int_value->getValue();
                 break;
-            case Predicate::opType::NE :
-                return this->value!= int_value->getValue();
+            case Predicate::opType::NE:
+                return this->value != int_value->getValue();
                 break;
-            case Predicate::opType::GT :
+            case Predicate::opType::GT:
                 return this->value > int_value->getValue();
                 break;
-            case Predicate::opType::LT :
+            case Predicate::opType::LT:
                 return this->value < int_value->getValue();
                 break;
-            case Predicate::opType::GE :
+            case Predicate::opType::GE:
                 return this->value >= int_value->getValue();
                 break;
-            case Predicate::opType::LE :
+            case Predicate::opType::LE:
                 return this->value <= int_value->getValue();
                 break;
             default:
@@ -37,12 +39,15 @@ namespace emerald
         } 
     };
 
-    int IntegerField::getValue() const{
+    int IntegerField::getValue() const {
+        // SEG FAULT
+        // value is a variable, not a pointer; should not be dereferenced
         return this->value;
     };
 
     /*copy constructor for integer field*/
-    IntegerField::IntegerField(const IntegerField& field):Field(field_type::INTEGER){
+    // exceeds 80 spaces
+    IntegerField::IntegerField(const IntegerField& field) : Field(field_type::INTEGER) {
         value = field.getValue();
     };
 } // emerald

--- a/src/database/join.cpp
+++ b/src/database/join.cpp
@@ -9,6 +9,8 @@
 namespace emerald
 {
     void NestedLoopJoinHelper(Database* db, JoinCondition* join_condition, JoinResult* result){
+    // function uses dynamic memory allocation
+    // function not declared in header
         /* Determine which columns in the table need to be joined. Assumption is that in the 
             predicate the first field correponds to table 1 and second field corresponds to table 2*/
         Predicate* join_predicate = join_condition->get_predicate();
@@ -66,6 +68,7 @@ namespace emerald
     };
 
     Table* NestedLoopJoin(Database* db, std::vector<JoinCondition*> join_conditions){
+    // function uses dyanmic memory allocation
         JoinResult* joined_table = new JoinResult(-1);
         /*
            Loop through the join conditions and join the tables
@@ -92,6 +95,8 @@ namespace emerald
         
     };
 
+    // function not declared in header
+    // function uses dynamic memory allocation
     void NestedLoopJoinHelper(JoinCondition* join_condition, JoinResult* result, std::vector<int> table_1_tuples, std::vector<int> table_2_tuples){
         /* Determine which columns in the table need to be joined. Assumption is that in the 
             predicate the first field correponds to table 1 and second field corresponds to table 2*/
@@ -123,6 +128,7 @@ namespace emerald
     };
 
     Table* NestedLoopJoin(std::vector<JoinCondition*> join_conditions, std::vector<std::vector<int>> filters){
+    // function uses dynamic memory allocation
         JoinResult* joined_table = new JoinResult(-1);
 
         int table_index=0;

--- a/src/database/join_result.cpp
+++ b/src/database/join_result.cpp
@@ -26,5 +26,6 @@ namespace emerald
             delete tuple;
         }
         tuples_.clear();
+    // not implemented?
     }
 } // emerald

--- a/src/database/order.cpp
+++ b/src/database/order.cpp
@@ -6,6 +6,7 @@
 namespace emerald
 {
     struct Comparator{
+    // should this be declared in header file?
         std::vector<int> fields;
         std::vector<bool> is_asc;
 

--- a/src/database/predicate.cpp
+++ b/src/database/predicate.cpp
@@ -1,38 +1,43 @@
 #include "predicate.h"
 
-namespace emerald
-{
-    Predicate::opType toOpType(std::string op){
-        if(op.compare("=")==0){
+namespace emerald {
+    /** 
+     * 1. Why use compare for strings?
+     * 2. Should this function's signature be declared in predicate.h?
+     * 3. Is it opstring being a valid op a prerequisite?
+     */
+    Predicate::opType toOpType(std::string op) {
+        if (op.compare("=") == 0) {
             return Predicate::opType::EQ;
-        } else if(op.compare("!=")==0){
+        } else if (op.compare("!=") == 0) {
             return Predicate::opType::NE;
-        } else if(op.compare(">")==0){
+        } else if (op.compare(">") == 0) {
             return Predicate::opType::GT;
-        } else if(op.compare("<")==0){
+        } else if (op.compare("<") == 0) {
             return Predicate::opType::LT;
-        } else if(op.compare(">=")==0){
+        } else if (op.compare(">=") == 0) {
             return Predicate::opType::GE;
         } else {
             return Predicate::opType::LE;
         }
     };
-
-    Predicate::Predicate(std::string column_name, std::string op, std::string value){
-        this->column = column_name;
+    
+    Predicate::Predicate(std::string column_name, std::string op, std::string value) {
+        this->column = column_name; // interface could be wrong here: no pointers in interface
         this->op = toOpType(op);
         this->value = value;
     };
 
-    std::string Predicate::getColumn(){
+    std::string Predicate::getColumn() {
         return this->column;
     };
 
-    std::string Predicate::getValue(){
+    std::string Predicate::getValue() {
         return this->value;
     };
 
-    Predicate::opType Predicate::getOp(){
+    Predicate::opType Predicate::getOp() {
         return this->op;
     };
+
 } // emerald

--- a/src/database/row_store.cpp
+++ b/src/database/row_store.cpp
@@ -5,56 +5,58 @@
 
 namespace emerald {
     
-    RowStore::RowStore(int table_id): Table(table_id, Table::ROW_STORE){};
+    RowStore::RowStore(int table_id): Table(table_id, Table::ROW_STORE){
+    };
     
-    void RowStore::insertTuple(Tuple* tuple){
-        tuples_.push_back(tuple);
-    };
-
-    void RowStore::print() const{
-        for(auto &tuple : tuples_){
-            tuple->print();
-        }
-    };
-
-    std::vector<Tuple*> RowStore::getTuples() const{
-        return tuples_;
-    };
-
-    // Returns size of the table
-    size_t RowStore::size() const{
-        return tuples_.size();
-    };
-
-    /* Used to populate the table by copying the tuples from another table.*/
-    void RowStore::copy_tuples(Table* table){
-        if (table->getStorageType()==Table::storageType::ROW_STORE) {
-            insert_tuples(static_cast<RowStore*>(table)->getTuples());
-        } 
-    };
-
-    /* Inserts the array of Tuples provided. This is a deep copy of the tuples */
-    void RowStore::insert_tuples(std::vector<Tuple*> tuples){
-        tuples_ = tuples;
-    };
-
-    /* Merges the given tuples and inserts the merged tuple into the table */
-    void RowStore::merge_and_insert(Tuple* tuple_1, Tuple* tuple_2){
-        Tuple* result = tuple_1; // this should do a deep copy of tuple_1 to result
-        result->append_fields(tuple_2->get_fields()); // this appends the rest of the fields to the result
-        insertTuple(result);
-    };
-
-    Tuple* RowStore::get_tuple(int index) const{
-        return tuples_[index];
-    }
-
-    RowStore::~RowStore(){
+    RowStore::~RowStore() {
         std::cout << "Calling clear\n";
         for(auto &tuple : tuples_){
             delete tuple;
         }
         tuples_.clear();
         std::cout << "Completed clear\n";
+    }
+
+    void RowStore::print() const {
+        for (auto &tuple : tuples_) {
+            tuple->print();
+        }
+    };
+
+    // Returns size of the table
+    size_t RowStore::size() const {
+        return tuples_.size();
+    };
+
+    void RowStore::insertTuple(Tuple* tuple) {
+        tuples_.push_back(tuple);
+    };
+
+
+    std::vector<Tuple*> RowStore::getTuples() const {
+        return tuples_;
+    };
+
+    /* Used to populate the table by copying the tuples from another table.*/
+    void RowStore::copy_tuples(Table* table) {
+        if (table->getStorageType()==Table::storageType::ROW_STORE) {
+            insert_tuples(static_cast<RowStore*>(table)->getTuples());
+        } 
+    };
+
+    /* Inserts the array of Tuples provided. This is a deep copy of the tuples */
+    void RowStore::insert_tuples(std::vector<Tuple*> tuples) {
+        tuples_ = tuples;
+    };
+
+    /* Merges the given tuples and inserts the merged tuple into the table */
+    void RowStore::merge_and_insert(Tuple* tuple_1, Tuple* tuple_2) {
+        Tuple* result = tuple_1; // this should do a deep copy of tuple_1 to result
+        result->append_fields(tuple_2->get_fields()); // this appends the rest of the fields to the result
+        insertTuple(result);
+    };
+
+    Tuple* RowStore::get_tuple(int index) const {
+        return tuples_[index];
     }
 };

--- a/src/database/string_field.cpp
+++ b/src/database/string_field.cpp
@@ -3,32 +3,35 @@
 
 namespace emerald
 {
-    StringField::StringField(std::string v):Field(field_type::STRING),value(v){};
+    // exceeds 80 chracters
+    StringField::StringField(std::string v) : Field(field_type::STRING), value(v) {
+    };
 
-    void StringField::print() const{
+    void StringField::print() const {
         std::cout << value << " \n";
     };
 
-    bool StringField::filter(Predicate::opType op, Field* value){
+    bool StringField::filter(Predicate::opType op, Field* value) {
         StringField* str_value = static_cast<StringField*>(value);
-        switch (op)
-        {
-            case Predicate::opType::EQ :
+        switch (op) {
+            // SEG FAULT
+            // value is a variable, not a pointer; should not be dereferenced
+            case Predicate::opType::EQ:
                 return this->value.compare(str_value->getValue())==0;
                 break;
-            case Predicate::opType::NE :
+            case Predicate::opType::NE:
                 return this->value.compare(str_value->getValue())!=0;
                 break;
-            case Predicate::opType::GT :
+            case Predicate::opType::GT:
                 return this->value.compare(str_value->getValue())>0;
                 break;
-            case Predicate::opType::LT :
+            case Predicate::opType::LT:
                 return this->value.compare(str_value->getValue())<0;
                 break;
-            case Predicate::opType::GE :
+            case Predicate::opType::GE:
                 return this->value.compare(str_value->getValue())>=0;
                 break;
-            case Predicate::opType::LE :
+            case Predicate::opType::LE:
                 return this->value.compare(str_value->getValue())<=0;
                 break;
             default:
@@ -38,6 +41,8 @@ namespace emerald
     };
 
     std::string StringField::getValue() const{
+        // SEG FAULT
+        // value is a variable, not a pointer; should not be dereferenced
         return this->value;
     };
 

--- a/src/database/summary.cpp
+++ b/src/database/summary.cpp
@@ -1,8 +1,7 @@
 #include "summary.h"
 
-namespace emerald
-{
-    Summary::Summary(SummaryType type){
+namespace emerald {
+    Summary::Summary(SummaryType type) {
         summary_type_ = type;
     }
 

--- a/src/database/summary_list.cpp
+++ b/src/database/summary_list.cpp
@@ -1,12 +1,10 @@
 #include "summary_list.h"
 
-namespace emerald
-{
-    SummaryList::SummaryList():Summary(SummaryType::SUMMARY_LIST){
-
+namespace emerald {
+    SummaryList::SummaryList():Summary(SummaryType::SUMMARY_LIST) {
     }
 
-    void SummaryList::add_tuple_set(TupleSet* tuple_set){
+    void SummaryList::add_tuple_set(TupleSet* tuple_set) {
         tuple_set_list_.push_back(tuple_set);
     }
 
@@ -14,7 +12,7 @@ namespace emerald
         return tuple_set_list_;
     }
 
-    size_t SummaryList::size() const{
+    size_t SummaryList::size() const {
         return tuple_set_list_.size();
     }
 } // emerald

--- a/src/database/table.cpp
+++ b/src/database/table.cpp
@@ -2,8 +2,7 @@
 #include <string>
 #include <iostream>
 
-namespace emerald
-{
+namespace emerald {
     Table::Table(int table_id, storageType storage_type){
         type = storage_type;
         table_id_ = table_id;

--- a/src/database/table_descriptor.cpp
+++ b/src/database/table_descriptor.cpp
@@ -3,73 +3,71 @@
 #include "field_type.h"
 #include <iostream>
 
-namespace emerald
-{
-    TableDescriptor::TableDescriptor(){
-        
+namespace emerald {
+    TableDescriptor::TableDescriptor() {
     }
 
-    TableDescriptor::TableDescriptor(int table_id, std::vector<std::string> column_names, std::vector<std::string> column_types){
-       for(size_t i = 0; i < column_names.size(); i++)
-       {
-           field_type type;
-           if(column_types[i].compare("INTEGER")==0){
-               type = field_type::INTEGER;
-           } else if(column_types[i].compare("STRING")==0){
-               type = field_type::STRING;
-           } else if(column_types[i].compare("BOOLEAN")==0){
-               type = field_type::BOOLEAN;
-           } else if(column_types[i].compare("DOUBLE")==0){
-               type = field_type::DOUBLE;
-           } else {
-               type = field_type::DATE;
-           }
-           columns_.push_back(new ColumnDescriptor(table_id, i, column_names[i], type)); 
-       }
-   };
-
-   void TableDescriptor::print() const{
-       std::cout << "Inside Table Descriptor print\n";
-       for(auto &column : columns_){
-           std::cout << column->get_column_name() << " : " << static_cast<std::underlying_type<field_type>::type>(column->get_column_type()) << '\n';
-       }
-   };
-
-    int TableDescriptor::getColumnId(std::string column_name) const{
-       for(size_t i = 0; i<columns_.size(); i++){
-           if(column_name.compare(columns_[i]->get_column_name())==0){
-               return i;
-           }
-       }
-       return -1;
-    };
-
-    field_type TableDescriptor::getColumnType(int index) const{
-       return columns_[index]->get_column_type();
-    };
-
+    // function uses dynamic memory allocation
+    TableDescriptor::TableDescriptor(int table_id, std::vector<std::string> column_names, std::vector<std::string> column_types) {
+        for (size_t i = 0; i < column_names.size(); i++) {
+            field_type type;
+            // why use compare?
+            if (column_types[i].compare("INTEGER") == 0) {
+                type = field_type::INTEGER;
+            } else if (column_types[i].compare("STRING") == 0) {
+                type = field_type::STRING;
+            } else if (column_types[i].compare("BOOLEAN") == 0) {
+                type = field_type::BOOLEAN;
+            } else if (column_types[i].compare("DOUBLE") == 0) {
+                type = field_type::DOUBLE;
+            } else {
+                type = field_type::DATE;
+            }
+            columns_.push_back(new ColumnDescriptor(table_id, i, column_names[i], type)); 
+        }
+    }; // redundant semicolon?
 
     TableDescriptor::TableDescriptor(const TableDescriptor &tableDesc){
         columns_ = tableDesc.get_columns();
     };
 
+    // function not declared in header file
+    void TableDescriptor::print() const {
+        std::cout << "Inside Table Descriptor print\n";
+        for (auto &column : columns_) {
+            std::cout << column->get_column_name() << " : " << static_cast<std::underlying_type<field_type>::type>(column->get_column_type()) << '\n';
+        }
+    }; // redundant semicolon?
+
+    int TableDescriptor::getColumnId(std::string column_name) const {
+        for (size_t i = 0; i<columns_.size(); i++) {
+            if (column_name.compare(columns_[i]->get_column_name()) == 0) {
+                return i;
+            }
+        }
+        return -1;
+    }; // redundant semicolon?
+
+    field_type TableDescriptor::getColumnType(int index) const {
+        return columns_[index]->get_column_type();
+    }; // redundant semicolon?
+
     //Appends the given array of columns to the existing columns array
-    void TableDescriptor::AppendColumns(std::vector<ColumnDescriptor*> columns){
-        for(auto column : columns)
-        {
+    void TableDescriptor::AppendColumns(std::vector<ColumnDescriptor*> columns) {
+        for (auto column : columns) {
             columns_.push_back(column);
         }
     };
 
-    std::vector<ColumnDescriptor*> TableDescriptor::get_columns() const{
+    std::vector<ColumnDescriptor*> TableDescriptor::get_columns() const {
         return columns_;
     }
 
-    ColumnDescriptor* TableDescriptor::get_column(std::string name) const{
-        for(auto &column : columns_){
-           if(name.compare(column->get_column_name())==0){
-               return column;
-           }
+    ColumnDescriptor* TableDescriptor::get_column(std::string name) const {
+        for (auto &column : columns_) {
+            if (name.compare(column->get_column_name()) == 0) {
+                return column;
+            }
         }
         return nullptr;
     }
@@ -78,7 +76,7 @@ namespace emerald
         return columns_[index];
     }
 
-    size_t TableDescriptor::size() const{
+    size_t TableDescriptor::size() const {
         return columns_.size();
     }
 } // emerald

--- a/src/database/tuple.cpp
+++ b/src/database/tuple.cpp
@@ -1,42 +1,40 @@
 #include "tuple.h"
 #include <iostream>
 
-namespace emerald
-{
-    Tuple::Tuple(){
-
+namespace emerald {
+    Tuple::Tuple() {
     }
     
-    Tuple::Tuple(std::vector<Field*> fields){
+    Tuple::Tuple(std::vector<Field*> fields) {
         fields_ = fields;
-    };
+        // does the tuple description need to be handled here?
+    }; // redundant semicolon?
 
-    void Tuple::print() const{
-        for(auto &field : fields_)
-        {
+    // Copy constructor for Tuple class
+    Tuple::Tuple(const Tuple& tuple) {
+        fields_ = tuple.get_fields();
+    }; // redundant semicolon?
+
+    void Tuple::print() const {
+        for (auto &field : fields_) {
             field->print();
         }
         std::cout << std::endl;
-    };
+    }; // redundant semicolon?
 
-    Field* Tuple::getField(int index) const{
+    Field* Tuple::getField(int index) const {
         return fields_[index];
-    };
+    }; // redundant semicolon?
 
-    // Copy constructor for Tuple class
-    Tuple::Tuple(const Tuple& tuple){
-        fields_ = tuple.get_fields();
-    };
-
-    std::vector<Field*> Tuple::get_fields() const{
+    std::vector<Field*> Tuple::get_fields() const {
         return fields_;
-    };
+    }; // redundant semicolon?
 
-    void Tuple::append_fields(std::vector<Field*> fields){
+    void Tuple::append_fields(std::vector<Field*> fields) {
         fields_.insert(fields_.end(), fields.begin(), fields.end());
-    };
+    }; // redundant semicolon?
 
-    void Tuple::add_field(Field* field){
+    void Tuple::add_field(Field* field) {
         fields_.push_back(field);
     }
 } // emerald

--- a/src/database/tuple_descriptor.cpp
+++ b/src/database/tuple_descriptor.cpp
@@ -1,13 +1,12 @@
 #include "tuple_descriptor.h"
 
-namespace emerald
-{
-    TupleDescriptor::TupleDescriptor(int table_id, int tuple_id){
+namespace emerald {
+    TupleDescriptor::TupleDescriptor(int table_id, int tuple_id) {
         table_id_ = table_id;
         tuple_id_ = tuple_id;
     }
 
-    int TupleDescriptor::get_table_id() const{
+    int TupleDescriptor::get_table_id() const {
         return table_id_;
     }
 
@@ -15,11 +14,11 @@ namespace emerald
         return tuple_id_;
     }
 
-    bool TupleDescriptor::equals(const TupleDescriptor* tuple_desc) const{
+    bool TupleDescriptor::equals(const TupleDescriptor* tuple_desc) const {
         return table_id_ == tuple_desc->get_table_id() && tuple_id_ == tuple_desc->get_tuple_id();
     }
 
-    TupleDescriptor::TupleDescriptor(const TupleDescriptor &tuple_desc){
+    TupleDescriptor::TupleDescriptor(const TupleDescriptor &tuple_desc) {
         table_id_ = tuple_desc.get_table_id();
         tuple_id_ = tuple_desc.get_tuple_id();
     }

--- a/src/database/tuple_set.cpp
+++ b/src/database/tuple_set.cpp
@@ -1,17 +1,15 @@
 #include "tuple_set.h"
 
-namespace emerald
-{
-    void TupleSet::insert(TupleDescriptor* tuple_desc){
+namespace emerald {
+    void TupleSet::insert(TupleDescriptor* tuple_desc) {
         tuple_descriptors_.push_back(tuple_desc);
     }
 
     // Given a table_id, this method returns the tuple id, in the tuple set, that belongs to the table
     // TO DO: If there are more than one tuple that belongs to the table, what should be done???
-    int TupleSet::get_tuple_id(int table_id){
-        for(auto &tuple_desc : tuple_descriptors_)
-        {
-            if (tuple_desc->get_table_id()==table_id) {
+    int TupleSet::get_tuple_id(int table_id) {
+        for (auto &tuple_desc : tuple_descriptors_) {
+            if (tuple_desc->get_table_id() == table_id) {
                 return tuple_desc->get_tuple_id();
             }
             
@@ -19,13 +17,15 @@ namespace emerald
         return -1;
     }
 
-    TupleSet::TupleSet(){}
+    TupleSet::TupleSet() {
+    }
 
-    bool TupleSet::equals(const TupleSet* tuple_set) const{
+    bool TupleSet::equals(const TupleSet* tuple_set) const {
         bool isEqual = true;
-        for(size_t i = 0; i < tuple_set->get_tuple_descs().size(); i++)
+        for (size_t i = 0; i < tuple_set->get_tuple_descs().size(); i++)
         {
-            if(!(tuple_descriptors_[i]->equals(tuple_set->get_tuple_descs()[i]))){
+            // line length exceeds 80 characters
+            if (!(tuple_descriptors_[i]->equals(tuple_set->get_tuple_descs()[i]))) {
                 isEqual = false;
                 break;
             }
@@ -33,11 +33,11 @@ namespace emerald
         return isEqual;
     }
 
-    std::vector<TupleDescriptor*> TupleSet::get_tuple_descs() const{
+    std::vector<TupleDescriptor*> TupleSet::get_tuple_descs() const {
         return tuple_descriptors_;
     }
 
-    TupleSet::TupleSet(const TupleSet &tuple_set){
+    TupleSet::TupleSet(const TupleSet &tuple_set) {
         tuple_descriptors_ = tuple_set.get_tuple_descs();
     }
 } // emerald

--- a/src/database/utility.cpp
+++ b/src/database/utility.cpp
@@ -15,30 +15,31 @@
 #include "summary_list.h"
 #include "column_store.h"
 
-namespace emerald
-{
-    Table::storageType toStorageType(std::string type){
-        if(type.compare("ROW_STORE")==0){
+namespace emerald {
+    // not declared; how does this compile successfully?
+    Table::storageType toStorageType(std::string type) {
+        // why use compare?
+        if (type.compare("ROW_STORE") == 0){
             return Table::ROW_STORE;
         } else {
             return Table::COLUMN_STORE;
         }
     }
 
-    void createTables(Database* db, std::string catalogFile, Table::storageType type){
+    void createTables(Database* db, std::string catalogFile, Table::storageType type) {
 
         std::ifstream catalog;
         catalog.open(catalogFile, std::ifstream::in);
 
-        if(catalog.is_open()){
+        if (catalog.is_open()) {
             std::string line;
-            while(getline(catalog, line)){
+            while (getline(catalog, line)) {
                 std::istringstream ss(line);
                 std::string tableName, column_name, column_type;
                 getline(ss, tableName, ',');
                 
                 std::vector<std::string> column_names, column_types;
-                while(getline(ss, column_name, ',')){
+                while (getline(ss, column_name, ',')) {
                     column_names.push_back(column_name);
                     getline(ss, column_type, ',');
                     column_types.push_back(column_type);
@@ -49,16 +50,17 @@ namespace emerald
         }
     }
 
-    Field* constructField(std::string field_value, field_type type){
+    // function uses dynamic memory allocation
+    Field* constructField(std::string field_value, field_type type) {
         Field* field = nullptr;
 
-        if(type==field_type::INTEGER){   
+        if (type == field_type::INTEGER) {
             field = new IntegerField(atoi(field_value.c_str()));
-        } else if(type==field_type::STRING){
+        } else if (type == field_type::STRING) {
             field = new StringField(field_value); 
-        } else if(type==field_type::DOUBLE){
+        } else if (type == field_type::DOUBLE) {
             field = new DoubleField(stod(field_value));
-        } else if(type==field_type::DATE){
+        } else if (type == field_type::DATE) {
             field = new DateField(field_value);
         } else {
             //need to fill it for boolean type
@@ -66,9 +68,10 @@ namespace emerald
         return field;
     }
 
-    void loadData(Database* db, std::string data_dir){
+    // function uses dynamic memory allocation
+    void loadData(Database* db, std::string data_dir) {
 
-        for(auto &x : db->getTableIds()){
+        for (auto &x : db->getTableIds()) {
 
             std::string table_name = x.first;
             //data files need to the same name as the tables
@@ -77,20 +80,20 @@ namespace emerald
 
             Table* table = db->getTable(x.second);
             std::vector<ColumnDescriptor*> columns = table->getTableDescriptor()->get_columns();
-            if(file.is_open()){
+            if (file.is_open()) {
                 
                 std::string line;
-                while(getline(file, line)){
+                while (getline(file, line)) {
                     std::istringstream ss(line);
                     std::vector<Field*> fields;
                     std::string field_value;
                     int index = 0;
-                    while(getline(ss, field_value, ',')){
+                    while (getline(ss, field_value, ',')) {
                          fields.push_back(constructField(field_value, columns[index]->get_column_type()));
                          index++;
                     }
                     
-                    if(table->getStorageType() == Table::ROW_STORE){
+                    if (table->getStorageType() == Table::ROW_STORE) {
                         Tuple* tuple = new Tuple(fields);
                         static_cast<RowStore*>(table)->insertTuple(tuple);
                     } else {
@@ -104,20 +107,16 @@ namespace emerald
         }
     }
 
-    void printSummaryTable(std::map<Dimension,Summary*> groups){
-        for(auto &entry : groups)
-        {
+    void printSummaryTable(std::map<Dimension,Summary*> groups) {
+        for (auto &entry : groups) {
             std::cout << "Dimension :" ;
-            for(auto &field : entry.first.get_fields())
-            {
+            for (auto &field : entry.first.get_fields()) {
                 field->print();
             }
 
             std::cout << "\n Summary :";
-            for(auto &tuple_set : static_cast<SummaryList*>(entry.second)->get_tuples())
-            {
-                for(auto &tuple_desc : tuple_set->get_tuple_descs())
-                {
+            for (auto &tuple_set : static_cast<SummaryList*>(entry.second)->get_tuples()) {
+                for (auto &tuple_desc : tuple_set->get_tuple_descs()) {
                     std::cout << "(" << tuple_desc->get_table_id() << ", " << tuple_desc->get_tuple_id() << "\n";
                 }
                 

--- a/src/include/column.h
+++ b/src/include/column.h
@@ -2,18 +2,22 @@
 #include "field.h"
 #include <vector>
 
-namespace emerald
-{
-    class Column
-    {
+namespace emerald {
+    class Column {
         private:
             std::vector<Field*> fields_;
+
         public:
             Column(/* args */);
+
             ~ Column();
+
             size_t size() const;
+
             void insert(Field* field);
+
             Field* get_field(int index) const;
+
             std::vector<Field*> get_fields() const;
     };
 } // emerald

--- a/src/include/column_descriptor.h
+++ b/src/include/column_descriptor.h
@@ -3,9 +3,8 @@
 #include "field_type.h"
 #include <string>
 
-namespace emerald
-{
-    class ColumnDescriptor{
+namespace emerald {
+    class ColumnDescriptor {
         private:
             int table_id_;
             int column_id_; //this is the column index in the original table
@@ -16,11 +15,14 @@ namespace emerald
 
             ColumnDescriptor(int table_id, int column_id, std::string column_name, field_type type);
 
+            ColumnDescriptor(const ColumnDescriptor &column_desc);
+
             std::string get_column_name() const;
+
             field_type get_column_type() const;
-            int get_table_id() const;
+
             int get_column_id() const;
 
-            ColumnDescriptor(const ColumnDescriptor &column_desc);
+            int get_table_id() const;
     };
 } // emerald

--- a/src/include/column_store.h
+++ b/src/include/column_store.h
@@ -7,12 +7,22 @@ namespace emerald
     class ColumnStore : public Table {
         private:
             std::vector<Column*> columns_; 
+
         public:
             ColumnStore(int table_id);
+
+            // destructor not declared or implemented; base implementation used
+
+            // possible to add override keyword
             void print() const;
+
+            // possible to add override keyword
             size_t size() const;
+
             void insert_tuple(std::vector<Field*> fields);
+
             std::vector<Column*> get_columns() const;
+
             Column* get_column(int index) const;
     };
 } // emerald

--- a/src/include/database.h
+++ b/src/include/database.h
@@ -12,13 +12,21 @@ namespace emerald {
             std::vector<Table*> tables;
         public:
             Database();
+
             void createTable(std::string table_name, std::vector<std::string> column_names, std::vector<std::string> column_types, Table::storageType type);
+
             Table* getTable(int index);
+
             std::vector<Table*> getTables();
+
             std::unordered_map<std::string, int> getTableIds();
+
             void printTable(std::string table_name);
+
             Table* getTableRef(std::string table_name);
+
             int getTableId(std::string table_name);
+
             Field* get_field(int table_id, int tuple_id, int column_id);
     };
 };

--- a/src/include/date_field.h
+++ b/src/include/date_field.h
@@ -4,16 +4,20 @@
 #include <ctime>
 #include <string>
 
-namespace emerald
-{
+namespace emerald {
     class DateField : public Field {
         private:
             std::time_t value;
+
         public:
             DateField(std::string v);
-            void print() const;
-            bool filter(Predicate::opType op, Field* value);
-            std::time_t getValue() const;
+
             DateField(const DateField& field);
+
+            void print() const;
+
+            bool filter(Predicate::opType op, Field* value);
+
+            std::time_t getValue() const;
     };
 } // emerald

--- a/src/include/dimension.h
+++ b/src/include/dimension.h
@@ -4,6 +4,7 @@
 
 namespace emerald
 {
+    // used for grouping in group.h / cpp
     class Dimension {
         private:
             std::vector<Field*> fields_;

--- a/src/include/double_field.h
+++ b/src/include/double_field.h
@@ -2,16 +2,20 @@
 
 #include "field.h"
 
-namespace emerald
-{
-    class DoubleField : public Field{
+namespace emerald {
+    class DoubleField : public Field {
         private:
             double value;
+
         public:
             DoubleField(double v);
-            void print() const;
-            bool filter(Predicate::opType op, Field* value);
-            double getValue() const;
+
             DoubleField(const DoubleField& field);
+
+            void print() const;
+
+            bool filter(Predicate::opType op, Field* value);
+
+            double getValue() const;
     };
 } // emerald

--- a/src/include/field.h
+++ b/src/include/field.h
@@ -3,20 +3,22 @@
 #include "field_type.h"
 #include "predicate.h"
 
-namespace emerald
-{
+namespace emerald {
   class Field
   {
     private:
       field_type type;
+    
     public:
       Field();
+      
       Field(field_type type);
-      virtual void print() const=0;
+      
+      virtual void print() const = 0;
+      
       // if filter returns true, the tuple/attribute value needs to be included in the result
-      virtual bool filter(Predicate::opType op, Field* value)=0;
+      virtual bool filter(Predicate::opType op, Field* value) = 0;
+
+      // maybe should declare copy constructor and getter as virtual here too
   };
-  
-  
-    
 }; // emerald

--- a/src/include/field_type.h
+++ b/src/include/field_type.h
@@ -1,8 +1,7 @@
 #pragma once
 
-namespace emerald
-{
-    enum field_type{
+namespace emerald {
+    enum field_type {
         INTEGER,
         STRING,
         BOOLEAN,

--- a/src/include/integer_field.h
+++ b/src/include/integer_field.h
@@ -2,16 +2,20 @@
 
 #include "field.h"
 
-namespace emerald
-{
-   class IntegerField : public Field{
+namespace emerald {
+   class IntegerField : public Field {
        private:
             int value;
+
         public:
             IntegerField(int v);
+
             void print() const;
+
             bool filter(Predicate::opType op, Field* value);
+
             int getValue() const;
+
             IntegerField(const IntegerField& field);
    }; 
 } // emerald

--- a/src/include/predicate.h
+++ b/src/include/predicate.h
@@ -2,27 +2,42 @@
 
 #include <string>
 
-namespace emerald
-{
+namespace emerald {
+
+/**
+ * Class for enabling comparisons for fields
+ */
     class Predicate {
         public:
+            
+            /**
+             * Indicates the type of comparison
+             */
             enum opType {
-                EQ,
-                NE,
-                GT,
-                LT,
-                GE,
-                LE
+                EQ, // equals
+                NE, // not equals
+                GT, // greater than
+                LT, // less than
+                GE, // greater than or equal
+                LE  // less than or equal
             };
+
             Predicate();
+            
             Predicate(std::string column_name, std::string op, std::string value);
+
             std::string getColumn();
+            
             std::string getValue();
+            
             opType getOp();
+
         private:
-            std::string column;
+            std::string column; // not sure what this is for, probably column store?
+            
             opType op;
-            std::string value;
+            
+            std::string value; // not sure what this is for
         
     };
 } // emerald

--- a/src/include/row_store.h
+++ b/src/include/row_store.h
@@ -8,16 +8,28 @@ namespace emerald
     class RowStore : public Table{
         private:
             std::vector<Tuple*> tuples_;
+
         public:
             RowStore(int table_id);
-            void insertTuple(Tuple* tuple);
-            void print() const;
-            std::vector<Tuple*> getTuples() const;
-            size_t size() const;
-            void copy_tuples(Table* table);
-            void insert_tuples(std::vector<Tuple*> tuples);
-            void merge_and_insert(Tuple* tuple_1, Tuple* tuple_2);
-            Tuple* get_tuple(int index) const;
+
             ~RowStore();
+
+            // possible to add override keyword
+            void print() const;
+
+            // possible to add override keyword
+            size_t size() const;
+
+            void insertTuple(Tuple* tuple);
+
+            std::vector<Tuple*> getTuples() const;
+
+            void copy_tuples(Table* table);
+
+            void insert_tuples(std::vector<Tuple*> tuples);
+
+            void merge_and_insert(Tuple* tuple_1, Tuple* tuple_2);
+
+            Tuple* get_tuple(int index) const;
     };
 }; // emerald

--- a/src/include/string_field.h
+++ b/src/include/string_field.h
@@ -3,16 +3,20 @@
 #include "field.h"
 #include <string>
 
-namespace emerald
-{
-    class StringField : public Field{
+namespace emerald {
+    class StringField : public Field {
         private:
             std::string value;
+
         public:
             StringField(std::string v);
+            
             void print() const;
+
             bool filter(Predicate::opType op, Field* value);
+
             std::string getValue() const;
+
             StringField(const StringField& field);
     };
 } // emerald

--- a/src/include/summary.h
+++ b/src/include/summary.h
@@ -2,19 +2,21 @@
 
 #include <cstddef>
 
-namespace emerald
-{
+namespace emerald {
     class Summary {
         public:
             enum SummaryType {
                 SUMMARY_INDEX,
                 SUMMARY_LIST
             };
+
             Summary(SummaryType type);
+
             SummaryType get_type() const;
-            virtual size_t size() const=0;
+
+            virtual size_t size() const = 0;
+
         private:
             SummaryType summary_type_;
-
     };
 } // emerald

--- a/src/include/summary_list.h
+++ b/src/include/summary_list.h
@@ -3,16 +3,19 @@
 #include "summary.h"
 #include "tuple_set.h"
 
-namespace emerald
-{
+namespace emerald {
     class SummaryList : public Summary {
         private:
             std::vector<TupleSet*> tuple_set_list_;
+
         public:
             SummaryList();
-            void add_tuple_set(TupleSet* tuple_set);
-            std::vector<TupleSet*> get_tuples() const;
-            size_t size() const;
 
+            void add_tuple_set(TupleSet* tuple_set);
+
+            std::vector<TupleSet*> get_tuples() const;
+
+            // can add override keyword here
+            size_t size() const;
     };
 } // emerald

--- a/src/include/table.h
+++ b/src/include/table.h
@@ -4,7 +4,7 @@
 #include "tuple.h"
 #include <unordered_map>
 
-namespace emerald{
+namespace emerald {
     class Table {
         public:
             enum storageType {
@@ -12,21 +12,37 @@ namespace emerald{
                 COLUMN_STORE,
                 JOIN_INDEX
             };
+
             Table();
+
             Table(int table_id, storageType type);
-            void setTableDesc(int table_id, std::vector<std::string> column_names, std::vector<std::string> column_types);
-            void printTableDesc() const;
-            virtual void print() const=0;
-            TableDescriptor* getTableDescriptor() const;
-            Table::storageType getStorageType() const;
-            void copyTableDesc(TableDescriptor* table_desc);
-            void merge_table_desc(TableDescriptor* table_desc);
-            virtual size_t size() const=0;
-            int get_table_id() const;
+
             virtual ~Table();
+
+            // line length exceeds 80 characters
+            void setTableDesc(int table_id, std::vector<std::string> column_names, std::vector<std::string> column_types);
+
+            void printTableDesc() const;
+
+            virtual void print() const = 0;
+
+            TableDescriptor* getTableDescriptor() const;
+
+            Table::storageType getStorageType() const;
+
+            void copyTableDesc(TableDescriptor* table_desc);
+
+            void merge_table_desc(TableDescriptor* table_desc);
+
+            virtual size_t size() const = 0;
+
+            int get_table_id() const;
+
         private:
             TableDescriptor* tableDesc;
+
             storageType type;  
+
             int table_id_;      
     };
 };

--- a/src/include/table_descriptor.h
+++ b/src/include/table_descriptor.h
@@ -5,23 +5,33 @@
 #include <unordered_map>
 #include "column_descriptor.h"
 
-namespace emerald
-{
-   class TableDescriptor
-   {
+namespace emerald {
+   class TableDescriptor {
     private:
        std::vector<ColumnDescriptor*> columns_; 
+
     public:
         TableDescriptor();
-        TableDescriptor(const TableDescriptor &tableDesc);
+
         TableDescriptor(int table_id, std::vector<std::string> column_names, std::vector<std::string> column_types);  
+
+        // copy constructor
+        TableDescriptor(const TableDescriptor &tableDesc);
+
         void print() const;    
+
         int getColumnId(std::string column_name) const;
+
         field_type getColumnType(int index) const;
+
         void AppendColumns(std::vector<ColumnDescriptor*> columns);
+
         std::vector<ColumnDescriptor*> get_columns() const;
+
         ColumnDescriptor* get_column(std::string name) const; 
+
         ColumnDescriptor* get_column(int index) const;
+
         size_t size() const;
    };
 }; // emerald

--- a/src/include/tuple.h
+++ b/src/include/tuple.h
@@ -3,18 +3,26 @@
 
 #include "field.h"
 
-namespace emerald{
-    class Tuple{
+namespace emerald {
+    class Tuple {
         private:
             std::vector<Field*> fields_;
+
         public:
             Tuple();
+
             Tuple(std::vector<Field*> fields);
-            void print() const;
-            Field* getField(int index) const;
+
             Tuple(const Tuple& tuple);
+
+            void print() const;
+             
+            Field* getField(int index) const;
+
             std::vector<Field*> get_fields() const;
+
             void append_fields(std::vector<Field*> fields);
+
             void add_field(Field* field);
     };
 };

--- a/src/include/tuple_descriptor.h
+++ b/src/include/tuple_descriptor.h
@@ -1,7 +1,8 @@
+// is this necessary? I am genuinely not sure.
 #pragma once
 
-namespace emerald
-{
+namespace emerald {
+    // not sure how this class works
     class TupleDescriptor {
         private:
             int table_id_;

--- a/src/include/tuple_set.h
+++ b/src/include/tuple_set.h
@@ -3,8 +3,8 @@
 #include "tuple_descriptor.h"
 #include "field.h"
 
-namespace emerald
-{
+namespace emerald {
+    // not sure what this class does
     class TupleSet {
         private:
             std::vector<TupleDescriptor*> tuple_descriptors_;

--- a/src/include/utility.h
+++ b/src/include/utility.h
@@ -6,10 +6,14 @@
 #include <string>
 #include <map>
 
-namespace emerald
-{
+namespace emerald {
+    // not sure where these functions are being used
     void createTables(Database* db, std::string catalogFile, Table::storageType type);
-    void loadData(Database* db, std::string data_dir);
+
     Field* constructField(std::string field_value, field_type type);
+
+    void loadData(Database* db, std::string data_dir);
+
     void printSummaryTable(std::map<Dimension, Summary*> groups);
+
 } // emerald


### PR DESCRIPTION
We performed some preliminary refactoring to the BuzzDB codebase, in an attempt to help us better understand the codebase, and also to move the codebase towards adherence towards the Google C++ Style Guide.

We should be doing more of the refactoring in due course, after completing the porting of Assignment 1.

---

Added whitespace and reorganized certain code chunks for the following files:

- table.h/cpp
- table_descriptor.h/cpp
- row_store.h/cpp
- column_store.h/cpp
- column.h/cpp
- column_descriptor.h/cpp
- tuple.h/cpp
- tuple_descriptor.h/cpp
- tuple_set.h/cpp
- predicate.h/cpp
- field.h/cpp
- field_type.h
- integer_field.h/cpp
- string_field.h/cpp
- date_field.h/cpp
- double_field.h/cpp
- database.h/cpp
- summary.h/cpp
- summary_list.h/cpp
- utility.h/cpp

Some pertinent comments were also added to certain files.

No logical changes were made.

Resultant codebase was built and tested, with the same results as e9c4469.

---

Please let us know if there is anything we should change or reverse.