### PR TITLE
Travis CI setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+dist: trusty
+sudo: false
+language: cpp
+os: linux
+compiler: gcc
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - gcc-7
+      - g++-7
+      - libgtest-dev
+      - libgoogle-glog-dev
+    update: true
+
+before_install: chmod +x ./ci/install_dependencies.sh
+install: ./ci/install_dependencies.sh
+script: 
+  - export CC=gcc-7
+  - export CXX=g++-7
+  - mkdir build
+  - cd build
+  - cmake -DCMAKE_BUILD_TYPE=Release ..
+  - make
+
+notifications:
+  email: false
+
+# References:
+# Travis CI Docs - Installing dependencies: https://docs.travis-ci.com/user/installing-dependencies/
+# How to tell cmake which compilers to use: https://stackoverflow.com/questions/41916656/how-to-use-travis-ci-to-build-modern-c-using-modern-cmake
+# (not used) How to install GTest into Travis CI: http://david-grs.github.io/cpp-clang-travis-cmake-gtest-coveralls-appveyor/
+#     git submodule command: https://git-scm.com/book/en/v2/Git-Tools-Submodules 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 Emerald
 -------
+[![Build Status](https://travis-ci.org/georgia-tech-db/buzzdb.svg?branch=master)](https://travis-ci.org/georgia-tech-db/buzzdb)
 
 a) Installing dependencies
 

--- a/ci/install_dependencies.sh
+++ b/ci/install_dependencies.sh
@@ -1,0 +1,5 @@
+  sudo apt-get install cmake
+  cd /usr/src/gtest
+  sudo cmake CMakeLists.txt
+  sudo make
+  sudo cp *.a /usr/lib


### PR DESCRIPTION
Resolves #2.

---

As of 29e9f29, Travis CI has not been configured to automatically run the built test suite as one of the tests are currently failing. Doing so would result in our master branch failing status checks.

**Automatic testing will be enabled once the failing test has been fixed.**